### PR TITLE
Add support for $psEditor API's

### DIFF
--- a/lib/extensionCommands.ts
+++ b/lib/extensionCommands.ts
@@ -1,0 +1,416 @@
+import * as Atom from "atom";
+import { LanguageClientConnection } from "atom-languageclient";
+import os = require("os");
+import { normalize } from "path";
+import path = require("path");
+import { RequestType } from "vscode-jsonrpc";
+import { getInputPrompt } from "./inputPrompt";
+import { Logger } from "./logging";
+import { getSingleMenuSelection, IMenuItem, InputMenuResultReason } from "./menuSelect";
+import { getDebugSessionFilePath } from "./utils";
+
+export class ShowChoicePromptRequest {
+    public static type =
+        new RequestType<IShowChoicePromptRequestArgs, IShowChoicePromptResponseBody, string, void>(
+            "powerShell/showChoicePrompt");
+}
+
+export class ShowInputPromptRequest {
+    public static type =
+        new RequestType<IShowInputPromptRequestArgs, IShowInputPromptResponseBody, string, void>(
+            "powerShell/showInputPrompt");
+}
+
+export class GetEditorContextRequest {
+    public static type =
+        new RequestType<{}, IEditorContext, void, void>(
+            "editor/getEditorContext");
+}
+
+export class InsertTextRequest {
+    public static type =
+        new RequestType<IInsertTextRequestArguments, EditorOperationResponse, void, void>(
+            "editor/insertText");
+}
+
+export class SetSelectionRequest {
+    public static type =
+        new RequestType<ISetSelectionRequestArguments, EditorOperationResponse, void, void>(
+            "editor/setSelection");
+}
+
+export class OpenFileRequest {
+    public static type =
+        new RequestType<string, EditorOperationResponse, void, void>(
+            "editor/openFile");
+}
+
+export class NewFileRequest {
+    public static type =
+        new RequestType<string, EditorOperationResponse, void, void>(
+            "editor/newFile");
+}
+
+export class CloseFileRequest {
+    public static type =
+        new RequestType<string, EditorOperationResponse, void, void>(
+            "editor/closeFile");
+}
+
+export class SaveFileRequest {
+    public static type =
+        new RequestType<string, EditorOperationResponse, void, void>(
+            "editor/saveFile");
+}
+
+export class ShowErrorMessageRequest {
+    public static type =
+        new RequestType<string, EditorOperationResponse, void, void>(
+            "editor/showErrorMessage");
+}
+
+export class ShowWarningMessageRequest {
+    public static type =
+        new RequestType<string, EditorOperationResponse, void, void>(
+            "editor/showWarningMessage");
+}
+
+export class ShowInformationMessageRequest {
+    public static type =
+        new RequestType<string, EditorOperationResponse, void, void>(
+            "editor/showInformationMessage");
+}
+
+export class SetStatusBarMessageRequest {
+    public static type =
+        new RequestType<IStatusBarMessageDetails, EditorOperationResponse, void, void>(
+            "editor/setStatusBarMessage");
+}
+
+export interface IChoiceDetails {
+    label: string;
+    helpMessage: string;
+}
+
+interface IShowInputPromptRequestArgs {
+    name: string;
+    label: string;
+}
+
+interface IShowInputPromptResponseBody {
+    responseText: string;
+    promptCancelled: boolean;
+}
+
+export interface IShowChoicePromptRequestArgs {
+    isMultiChoice: boolean;
+    caption: string;
+    message: string;
+    choices: IChoiceDetails[];
+    defaultChoices: number[];
+}
+
+export interface IShowChoicePromptResponseBody {
+    responseText: string;
+    promptCancelled: boolean;
+}
+
+export interface IExtensionCommand {
+    name: string;
+    displayName: string;
+}
+
+export interface IRange {
+    start: IPosition;
+    end: IPosition;
+}
+
+export interface IPosition {
+    line: number;
+    character: number;
+}
+
+export interface IEditorContext {
+    currentFilePath: string;
+    cursorPosition: IPosition;
+    selectionRange: IRange;
+}
+
+export interface IInsertTextRequestArguments {
+    filePath: string;
+    insertText: string;
+    insertRange: IRange;
+}
+
+export interface ISetSelectionRequestArguments {
+    selectionRange: IRange;
+}
+
+export interface IStatusBarMessageDetails {
+    message: string;
+    timeout?: number;
+}
+
+export enum EditorOperationResponse {
+    Unsupported = 0,
+    Completed,
+}
+
+export class ExtensionCommands {
+    private clientConnection: LanguageClientConnection;
+
+    public setLanguageClient(languageClientConnection: LanguageClientConnection, log: Logger) {
+        this.clientConnection = languageClientConnection;
+
+        this.clientConnection._onRequest(
+            ShowInputPromptRequest.type,
+            (promptDetails) => this.showInputPrompt(promptDetails));
+
+        this.clientConnection._onRequest(
+            ShowChoicePromptRequest.type,
+            (promptDetails) => this.showChoicePrompt(promptDetails));
+
+        this.clientConnection._onRequest(
+            GetEditorContextRequest.type,
+            (details) => this.getEditorContext());
+
+        this.clientConnection._onRequest(
+            InsertTextRequest.type,
+            (details) => this.insertText(details));
+
+        this.clientConnection._onRequest(
+            SetSelectionRequest.type,
+            (details) => this.setSelection(details));
+
+        this.clientConnection._onRequest(
+            OpenFileRequest.type,
+            (filePath) => this.openFile(filePath));
+
+        this.clientConnection._onRequest(
+            NewFileRequest.type,
+            (filePath) => this.newFile());
+
+        this.clientConnection._onRequest(
+            CloseFileRequest.type,
+            (filePath) => this.closeFile(filePath));
+
+        this.clientConnection._onRequest(
+            SaveFileRequest.type,
+            (filePath) => this.saveFile(filePath));
+
+        this.clientConnection._onRequest(
+            ShowErrorMessageRequest.type,
+            (message) => this.showErrorMessage(message));
+
+        this.clientConnection._onRequest(
+            ShowWarningMessageRequest.type,
+            (message) => this.showWarningMessage(message));
+
+        this.clientConnection._onRequest(
+            ShowInformationMessageRequest.type,
+            (message) => this.showInformationMessage(message));
+    }
+
+    private showInputPrompt(promptDetails: IShowInputPromptRequestArgs): Thenable<IShowInputPromptResponseBody> {
+        return getInputPrompt(promptDetails.name).then(
+            (result) => {
+                return {
+                    promptCancelled: result.reason === InputMenuResultReason.Cancelled,
+                    responseText: result.value,
+                };
+            });
+    }
+
+    private showChoicePrompt(promptDetails: IShowChoicePromptRequestArgs): Thenable<IShowChoicePromptResponseBody> {
+        if (promptDetails.isMultiChoice) {
+            // TODO: Add multi choice select menu.
+            return Promise.reject("Multiple select is not currently supported.");
+        }
+
+        return getSingleMenuSelection<IChoiceDetails>(promptDetails.message, asSelectMenuItems(promptDetails.choices))
+            .then((result) => {
+                return {
+                    promptCancelled: result.reason === InputMenuResultReason.Cancelled,
+                    responseText: result.value.label,
+                };
+            });
+    }
+
+    private getEditorContext(): IEditorContext {
+        const editor = atom.workspace.getActiveTextEditor();
+        return {
+            currentFilePath: editor.getPath(),
+            cursorPosition: asPosition(editor.getCursorBufferPosition()),
+            selectionRange: asRange(editor.getSelectedBufferRange()),
+        };
+    }
+
+    private insertText(details: IInsertTextRequestArguments): EditorOperationResponse {
+        atom.workspace
+            .getActiveTextEditor()
+            .setTextInBufferRange(
+                asAtomRange(details.insertRange),
+                details.insertText);
+
+        return EditorOperationResponse.Completed;
+    }
+
+    private setSelection(details: ISetSelectionRequestArguments): EditorOperationResponse {
+        atom.workspace
+            .getActiveTextEditor()
+            .setSelectedBufferRange(
+                asAtomRange(details.selectionRange));
+
+        return EditorOperationResponse.Completed;
+    }
+
+    private openFile(filePath: string): Thenable<EditorOperationResponse> {
+        return atom.workspace
+            .open(this.normalizeFilePath(filePath))
+            .then(() => EditorOperationResponse.Completed);
+    }
+
+    private newFile(): Thenable<EditorOperationResponse> {
+        return atom.workspace.open()
+            .then(() => EditorOperationResponse.Completed);
+    }
+
+    private closeFile(filePath: string): EditorOperationResponse {
+        const targetEditor = this.findOpenTextEditor(filePath);
+        if (targetEditor === undefined || targetEditor === null) {
+            return EditorOperationResponse.Completed;
+        }
+
+        // This should either throw, save first, or have a force parameter.
+        if (targetEditor.isModified) {
+            return EditorOperationResponse.Completed;
+        }
+
+        // Better way to close?
+        targetEditor.getBuffer().destroy();
+        return EditorOperationResponse.Completed;
+    }
+
+    private saveFile(filePath: string): Thenable<EditorOperationResponse> {
+        const targetEditor = this.findOpenTextEditor(filePath);
+        if (targetEditor === undefined || targetEditor === null) {
+            return Promise.resolve(EditorOperationResponse.Completed);
+        }
+
+        if (!targetEditor.isModified) {
+            return Promise.resolve(EditorOperationResponse.Completed);
+        }
+
+        return targetEditor
+            .save()
+            .then(() => EditorOperationResponse.Completed);
+    }
+
+    private showErrorMessage(message: string): EditorOperationResponse {
+        atom.notifications.addError(message);
+        return EditorOperationResponse.Completed;
+    }
+
+    private showWarningMessage(message: string): EditorOperationResponse {
+        atom.notifications.addWarning(message);
+        return EditorOperationResponse.Completed;
+    }
+
+    private showInformationMessage(message: string): EditorOperationResponse {
+        atom.notifications.addInfo(message);
+        return EditorOperationResponse.Completed;
+    }
+
+    private setStatusBarMessage(details: IStatusBarMessageDetails): EditorOperationResponse {
+        // TODO: Add support for this. Should be pretty easy.
+        return EditorOperationResponse.Unsupported;
+    }
+
+    private findOpenTextEditor(filePath: string): Atom.TextEditor {
+        filePath = this.normalizeFilePath(filePath);
+        return atom.workspace
+            .getTextEditors()
+            .find((editor) => this.normalizeFilePath(editor.getPath()) === filePath);
+    }
+
+    private normalizeFilePath(filePath: string): string {
+        const platform = os.platform();
+        if (platform === "win32") {
+            // Make sure the file path is absolute
+            if (!path.win32.isAbsolute(filePath)) {
+                filePath = path.win32.resolve(
+                    atom.project.getPaths()[0],
+                    filePath);
+            }
+
+            // Normalize file path case for comparison for Windows
+            return filePath.toLowerCase();
+        } else {
+            // Make sure the file path is absolute
+            if (!path.isAbsolute(filePath)) {
+                filePath = path.resolve(
+                    atom.project.getPaths()[0],
+                    filePath);
+            }
+
+            // macOS is case-insensitive
+            if (platform === "darwin") {
+                filePath = filePath.toLowerCase();
+            }
+
+            return  filePath;
+        }
+    }
+}
+
+function asSelectMenuItems(choices: IChoiceDetails[]): Array<IMenuItem<IChoiceDetails>> {
+    return choices.map((choice) => {
+        return {
+            display: choice.helpMessage,
+            name: choice.label,
+            value: choice,
+        };
+    });
+}
+
+function asPosition(value: Atom.Point): IPosition {
+    if (value === undefined) {
+        return undefined;
+    } else if (value === null) {
+        return null;
+    }
+
+    return {
+        character: value.column,
+        line: value.row,
+    };
+}
+
+function asRange(value: Atom.Range): IRange {
+    if (value === undefined) {
+        return undefined;
+    } else if (value === null) {
+        return null;
+    }
+
+    return {
+        end: asPosition(value.end),
+        start: asPosition(value.start),
+    };
+}
+
+function asAtomPoint(value: IPosition): Atom.Point {
+    return new Atom.Point(value.line, value.character);
+}
+
+function asAtomRange(value: IRange): Atom.Range {
+    if (value === undefined) {
+        return undefined;
+    } else if (value === null) {
+        return null;
+    }
+
+    return new Atom.Range(
+        asAtomPoint(value.start),
+        asAtomPoint(value.end));
+}

--- a/lib/inputPrompt.ts
+++ b/lib/inputPrompt.ts
@@ -1,0 +1,103 @@
+import { CompositeDisposable, Panel, TextEditor, TextEditorElement } from "atom";
+import { EventEmitter } from "events";
+import { IInputMenuResult, InputMenuResultReason } from "./menuSelect";
+/**
+ * Creates an input prompt and presents it to the user.
+ * @export
+ * @param {string} message - The message to be displayed under the prompt describing the prompt's purpose.
+ * @returns {Promise<IInputMenuResult<string>>} - The text input by the user.
+ */
+export async function getInputPrompt(message: string): Promise<IInputMenuResult<string>> {
+    return await new InputPrompt(message).getResult();
+}
+
+class InputPrompt {
+    public element: HTMLElement;
+
+    private editor: TextEditor;
+    private emitter: EventEmitter;
+    private disposables: CompositeDisposable;
+    private activePanel: Panel;
+    private previouslyFocusedElement: HTMLElement;
+    private editorElement: TextEditorElement;
+
+    constructor(message: string) {
+        this.disposables = new CompositeDisposable();
+        this.emitter = new EventEmitter();
+        this.editor = new TextEditor({ mini: true });
+
+        this.element = document.createElement("div");
+        this.editorElement = atom.views.getView(this.editor);
+        this.element.appendChild(this.editorElement);
+
+        const messageElement = document.createElement("div");
+        messageElement.textContent = message;
+        messageElement.style.fontWeight = "bold";
+
+        this.element.appendChild(messageElement);
+    }
+
+    public async getResult(): Promise<IInputMenuResult<string>> {
+        this.show();
+        try {
+            return await this.waitForConfirmation();
+        } finally {
+            this.dispose();
+        }
+    }
+
+    private dispose(): void {
+        this.disposables.dispose();
+        if (this.previouslyFocusedElement !== null) {
+            this.previouslyFocusedElement.focus();
+            this.previouslyFocusedElement = null;
+        }
+
+        if (this.activePanel === null) {
+            return;
+        }
+
+        this.activePanel.destroy();
+    }
+
+    private waitForConfirmation(): Thenable<IInputMenuResult<string>> {
+        return new Promise((resolve, reject) => {
+            this.emitter.once(
+                "inputPromptCompleted",
+                (result: IInputMenuResult<string>) => resolve(result));
+        });
+    }
+
+    private show() {
+        this.previouslyFocusedElement = document.activeElement as HTMLElement;
+        this.activePanel = atom.workspace.addModalPanel({ item: this });
+        this.disposables.add(
+            atom.commands.add(this.element, {
+                "core:cancel": (event) => {
+                    this.cancel();
+                    event.stopPropagation();
+                },
+                "core:confirm": (event) => {
+                    this.confirm();
+                    event.stopPropagation();
+                },
+            }));
+
+        this.editorElement.focus();
+        this.editorElement.addEventListener("blur", () => this.cancel());
+    }
+
+    private confirm(): void {
+        this.emitter.emit("inputPromptCompleted", {
+            reason: InputMenuResultReason.Completed,
+            value: this.editor.getText(),
+        } as IInputMenuResult<string>);
+    }
+
+    private cancel(): void {
+        this.emitter.emit("inputPromptCompleted", {
+            reason: InputMenuResultReason.Cancelled,
+            value: "",
+        } as IInputMenuResult<string>);
+    }
+}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -10,6 +10,7 @@ import { PowerShellProcess, LanguageServerProcess } from './process';
 import { PlatformDetails, getPlatformDetails, getDefaultPowerShellPath } from './platform';
 import { ITerminalService } from './terminalService';
 import { Logger } from './logging';
+import { ExtensionCommands } from "./extensionCommands";
 
 // NOTE: We will need to find a better way to deal with the required
 //       PS Editor Services version...
@@ -26,6 +27,7 @@ class PowerShellLanguageClient extends AutoLanguageClient {
   private terminalTabServiceResolver: (ITerminalService) => void;
   private supportedExtensions = [ ".ps1", ".psm1", ".ps1xml" ];
   private platformDetails: PlatformDetails;
+  private extensionCommands: ExtensionCommands;
 
   // This is defined in the base class, redefined for typings
   public socket: net.Socket;
@@ -77,6 +79,8 @@ class PowerShellLanguageClient extends AutoLanguageClient {
   }
 
   public postInitialization(server) {
+    this.extensionCommands = new ExtensionCommands();
+    this.extensionCommands.setLanguageClient(server.connection, this.log);
   }
 
   private async ensureEditorServicesIsInstalled() {

--- a/lib/menuSelect.ts
+++ b/lib/menuSelect.ts
@@ -1,0 +1,256 @@
+import { Panel } from "atom";
+import * as SelectListView from "atom-select-list";
+import { EventEmitter } from "events";
+
+/**
+ * Creates a selection menu from the supplied items and presents it to the user.
+ * @export
+ * @template TItem - The menu item value type.
+ * @param {string} message - The message to display under the query prompt describing the menu's purpose.
+ * @param {Array<IMenuItem<TItem>>} items - The items to display.
+ * @param {number} [defaultIndex=null] - The index of the value to return if the user does not select an item.
+ * @returns {Promise<IInputMenuResult<TItem>>} - The value of the item selected.
+ */
+export async function getSingleMenuSelection<TItem>(
+    message: string,
+    items: Array<IMenuItem<TItem>>,
+    defaultIndex: number = null)
+    : Promise<IInputMenuResult<TItem>> {
+
+    if (defaultIndex !== null && (defaultIndex > items.length - 1 || defaultIndex < 0)) {
+        throw new RangeError();
+    }
+
+    const result = await new SingleItemSelectMenu<TItem>(message, items).getResult();
+    if (result.reason === InputMenuResultReason.Cancelled) {
+        return result;
+    }
+
+    if (defaultIndex === null) {
+        return result;
+    }
+
+    if (result.value === null || result.value === undefined) {
+        result.value = items[defaultIndex].value;
+    }
+
+    return result;
+}
+
+/**
+ * Represents an item in the menu.
+ * @export
+ * @interface IMenuItem
+ * @template TItem - The type of value stored by this item.
+ */
+export interface IMenuItem<TItem> {
+    value: TItem;
+    name: string;
+    display: string;
+}
+
+/**
+ * Represents the result of a selection menu.
+ * @export
+ * @interface IItemSelectMenuResult
+ * @template TItem - The menu item value type.
+ */
+export interface IInputMenuResult<TItem> {
+    reason: InputMenuResultReason;
+    value: TItem;
+}
+
+/**
+ * Represents the reason the menu closed.
+ * @export
+ * @enum {number}
+ */
+export enum InputMenuResultReason {
+    Completed,
+    Cancelled,
+}
+
+/**
+ * Represents a common base for menu selection classes.
+ * @abstract
+ * @class ItemSelectMenuBase
+ * @template TItem - The menu item value type.
+ * @template TResult - The type of the return value.
+ */
+abstract class ItemSelectMenuBase<TItem, TResult> {
+    protected panel: ItemSelectMenuPanel<TItem>;
+    protected transformElement: (element: HTMLElement, item: IMenuItem<TItem>) => HTMLElement;
+    private emitter: EventEmitter;
+
+    constructor(message: string, items: Array<IMenuItem<TItem>>) {
+        this.emitter = new EventEmitter();
+        this.panel = new ItemSelectMenuPanel<TItem>({
+            didCancelSelection: () => this.cancel(),
+            didConfirmSelection: (item) => this.onItemSelected(item),
+            elementForItem: (item) => this.createElementForItem(item),
+            infoMessage: message,
+            items,
+        });
+    }
+
+    /**
+     * Presents the menu to the user and waits for a selection.
+     * @returns {Promise<IInputMenuResult<TResult>>} The value of the selected item.
+     * @memberof ItemSelectMenuBase
+     */
+    public async getResult(): Promise<IInputMenuResult<TResult>> {
+        try {
+            this.panel.attach();
+            return await this.waitForCompletion();
+        } finally {
+            this.closeMenu();
+        }
+    }
+
+    /**
+     * Called when an item is selected by the user. Implementations should store the result
+     * or call the complete method.
+     * @protected
+     * @abstract
+     * @param {IMenuItem<TItem>} item - The item selected.
+     * @memberof ItemSelectMenuBase
+     */
+    protected abstract onItemSelected(item: IMenuItem<TItem>): void;
+
+    /**
+     * Signals that the result is ready to be returned and the menu can be closed.
+     * @protected
+     * @param {TResult} result - The raw result value of the menu selection(s).
+     * @memberof ItemSelectMenuBase
+     */
+    protected complete(result: TResult) {
+        this.emitter.emit("menuSelectCompleted", {
+            reason: InputMenuResultReason.Completed,
+            value: result,
+        } as IInputMenuResult<TResult>);
+    }
+
+    /**
+     * Signals that the menu should be canceled.
+     * @protected
+     * @memberof ItemSelectMenuBase
+     */
+    protected cancel() {
+        this.emitter.emit("menuSelectCompleted", {
+            reason: InputMenuResultReason.Cancelled,
+            result: null,
+        });
+    }
+
+    private closeMenu() {
+        this.panel.dispose();
+    }
+
+    private maybeTransformElement(element: HTMLElement, item: IMenuItem<TItem>): HTMLElement {
+        if (this.transformElement === null || this.transformElement === undefined) {
+            return element;
+        }
+
+        return this.transformElement(element, item);
+    }
+
+    private createElementForItem(item: IMenuItem<TItem>) {
+        const listItem = document.createElement("li");
+
+        const key = document.createElement("span");
+        const keyContent = document.createElement("strong");
+        keyContent.textContent = item.name;
+
+        key.appendChild(keyContent);
+        listItem.appendChild(key);
+        if (item.display === null || item.display === undefined || item.display === "") {
+            return this.maybeTransformElement(listItem, item);
+        }
+
+        const description = document.createElement("span");
+        const descriptionContent = document.createElement("small");
+        descriptionContent.textContent = " " + item.display;
+
+        description.appendChild(descriptionContent);
+        listItem.appendChild(description);
+        return this.maybeTransformElement(listItem, item);
+    }
+
+    private waitForCompletion(): Thenable<IInputMenuResult<TResult>> {
+        return new Promise((resolve, reject) => {
+            this.emitter.once(
+                "menuSelectCompleted",
+                (result: IInputMenuResult<TResult>) => resolve(result));
+        });
+    }
+}
+
+/**
+ * Represents a selection menu that closes after the first selection and returns the value stored
+ * in the menu item.
+ * @class SingleItemSelectMenu
+ * @extends {ItemSelectMenuBase<TItem, TItem>}
+ * @template TItem - The menu item value type.
+ */
+class SingleItemSelectMenu<TItem> extends ItemSelectMenuBase<TItem, TItem> {
+    /**
+     * An implementation of onItemSelected that completes the menu after the first selection.
+     * @protected
+     * @param {IMenuItem<TItem>} item - The item selected.
+     * @memberof SingleItemSelectMenu
+     */
+    protected onItemSelected(item: IMenuItem<TItem>) {
+        this.complete(item.value);
+    }
+}
+
+/**
+ * Represents the arguments required to create a ItemSelectMenuPanel.
+ * @interface IItemSelectMenuPanelArguments
+ * @template TItem - The menu item value type
+ */
+interface IItemSelectMenuPanelArguments<TItem> {
+    didCancelSelection: () => void;
+    didConfirmSelection: (item: IMenuItem<TItem>) => void;
+    elementForItem: (item: IMenuItem<TItem>) => HTMLElement;
+    infoMessage: string;
+    items: Array<IMenuItem<TItem>>;
+}
+
+/**
+ * Represents the panel element used for menu selections.
+ * @class ItemSelectMenuPanel
+ * @template TItem - The menu item value type.
+ */
+class ItemSelectMenuPanel<TItem> {
+    private view: SelectListView;
+    private activePanel: Panel;
+    private previouslyFocusedElement: HTMLElement;
+
+    constructor(args: IItemSelectMenuPanelArguments<TItem>) {
+        args = Object.assign(args, {
+            filterKeyForItem: (item: IMenuItem<TItem>) => item.name + item.display,
+        });
+
+        this.view = new SelectListView(args);
+    }
+
+    public get element(): HTMLElement {
+        return this.view.element;
+    }
+
+    public dispose() {
+        this.activePanel.destroy();
+        this.view.destroy();
+        if (this.previouslyFocusedElement !== null) {
+            this.previouslyFocusedElement.focus();
+            this.previouslyFocusedElement = null;
+        }
+    }
+
+    public attach() {
+        this.previouslyFocusedElement = document.activeElement as HTMLElement;
+        this.activePanel = atom.workspace.addModalPanel<ItemSelectMenuPanel<TItem>>({ item: this });
+        this.view.focus();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "atom-languageclient": "^0.8.1",
     "atom-ts-transpiler": "^1.2.4",
     "atom-package-deps": "^4.6.1",
+    "atom-select-list": "^0.7.0",
     "typescript": "^2.6.1",
     "decompress": "^4.2.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",
-        "lib": ["es6"],
+        "lib": ["es6", "dom"],
         "sourceMap": true
     }
 }


### PR DESCRIPTION
This change adds support for all `$psEditor` API's except `SetStatusBarMessage`, the multiple choice variant of `ShowChoicePrompt` and editor command related API's.

Some classes/functions were also created to enable consistent support for the choice and input prompts. These can be reused in other features when added like the `Find`/`Install-Module` commands from the VSCode extension.

Resolves #5